### PR TITLE
Test PA TX flatness

### DIFF
--- a/software/hl2setup/hl2.cxx
+++ b/software/hl2setup/hl2.cxx
@@ -1241,22 +1241,22 @@ static int read_rx_udp10(int want_samples)	// Read samples from UDP using the He
 
 static void Bias0code(int code)
 {
-	hw_command[0] = 0x3D;
-	hw_command[1] = 0x06;
-	hw_command[2] = 0xAC;
-	hw_command[3] = 0x00;
-	hw_command[4] = (unsigned char)code;
+	hw_command[0] = 0x3D; // ADDR
+	hw_command[1] = 0x06; // I2C2 cookie, must be 0x06 to write
+	hw_command[2] = 0xAC; // I2C2 stop at end + target chip address
+	hw_command[3] = 0x00; // I2C2 control: MCP4662 Command Byte: Address 0, write data
+	hw_command[4] = (unsigned char)code; // I2C2 data: MCP4662 Data Byte
 	hw_command_state = 1;
 	hw_command_start = QuiskTimeSec();
 }
 
 static void Bias1code(int code)
 {
-	hw_command[0] = 0x3D;
-	hw_command[1] = 0x06;
-	hw_command[2] = 0xAC;
-	hw_command[3] = 0x10;
-	hw_command[4] = (unsigned char)code;
+	hw_command[0] = 0x3D; // ADDR
+	hw_command[1] = 0x06; // I2C2 cookie, must be 0x06 to write
+	hw_command[2] = 0xAC; // I2C2 stop at end + target chip address
+	hw_command[3] = 0x10; // I2C2 control: MCP4662 Command Byte: Address 1, write data
+	hw_command[4] = (unsigned char)code; // I2C2 data: MCP4662 Data Byte
 	hw_command_state = 1;
 	hw_command_start = QuiskTimeSec();
 }

--- a/software/hl2setup/hl2.h
+++ b/software/hl2setup/hl2.h
@@ -44,3 +44,5 @@ extern int verbose_output;
 #define SIGNAL_LEVEL		110
 #define FILTER_BOARD		160
 #define PA  190
+#define STATE_START_TEST_TX_FLATNESS 200
+#define TEST_TX_FLATNESS 205

--- a/software/hl2setup/hl2setup.cxx
+++ b/software/hl2setup/hl2setup.cxx
@@ -14,13 +14,15 @@
 
 #include <hl2.h>
 
-
+//#define CFG_BIAS_BUTTONS
+//#define CFG_FLATNESS_BUTTON
 
 void idle(void *);
 void exit_callback(Fl_Widget*, void*);
 void btn_setup_callback(Fl_Widget *, void *);
 void btn_test_bias_callback(Fl_Widget *, void *);
 void btn_set_bias_callback(Fl_Widget *, void *);
+void btn_test_pwr_flatness_button_callback(Fl_Widget *, void *);
 void btn_power_callback(Fl_Widget *, void *);
 
 int verbose_output;
@@ -29,8 +31,13 @@ class MainWindow : public Fl_Window
 {
 private:
 	Fl_Button * setup_button;
-	//Fl_Button * set_bias_button;
-	//Fl_Button * test_bias_button;
+#ifdef CFG_BIAS_BUTTONS
+	Fl_Button * set_bias_button;
+	Fl_Button * test_bias_button;
+#endif // CFG_BIAS_BUTTONS
+#ifdef CFG_FLATNESS_BUTTON
+	Fl_Button * test_pwr_flatness_button;
+#endif // CFG_FLATNESS_BUTTON
 	const char * help_text;
 public:
 	Fl_Light_Button * power_button;
@@ -134,18 +141,25 @@ public:
 		ww = width1 * 70 / 100;
 		hh = height * 2;
 		x0 = tab1 * 2;
-		dx = (info_width - tab1 * 2 - ww * 3) / 2;
+		dx = (info_width - tab1 * 2 - ww * 4) / 2;
 		dx = ww + dx;
 		setup_button = new Fl_Button(x0, y, ww, hh, "Test");
 		setup_button->callback(btn_setup_callback);
 		setup_button->deactivate();
-		//test_bias_button = new Fl_Button(x0 + dx, y, ww, hh, "Test PA Bias");
-		//test_bias_button->callback(btn_test_bias_callback);
-		//test_bias_button->when(FL_WHEN_CHANGED);
-		//test_bias_button->deactivate();
-		//set_bias_button = new Fl_Button(x0 + dx * 2, y, ww, hh, "Set PA Bias");
-		//set_bias_button->callback(btn_set_bias_callback);
-		//set_bias_button->deactivate();
+#ifdef CFG_BIAS_BUTTONS
+		test_bias_button = new Fl_Button(x0 + dx, y, ww, hh, "Test PA Bias");
+		test_bias_button->callback(btn_test_bias_callback);
+		test_bias_button->when(FL_WHEN_CHANGED);
+		test_bias_button->deactivate();
+		set_bias_button = new Fl_Button(x0 + dx * 2, y, ww, hh, "Set PA Bias");
+		set_bias_button->callback(btn_set_bias_callback);
+		set_bias_button->deactivate();
+#endif // CFG_BIAS_BUTTONS
+#ifdef CFG_FLATNESS_BUTTON
+		test_pwr_flatness_button = new Fl_Button(x0 + dx * 3, y, ww, hh, "Test flatness");
+		test_pwr_flatness_button->callback(btn_test_pwr_flatness_button_callback);
+		test_pwr_flatness_button->deactivate();
+#endif // CFG_FLATNESS_BUTTON
 		y += hh + height;
 	
 		hh = height * 24;
@@ -175,11 +189,21 @@ public:
 		//	set_bias_button->deactivate();
 		if (hermes_run_state == STATE_IDLE && code_version >= 60) {
 			setup_button->activate();
-			//test_bias_button->activate();
+#ifdef CFG_BIAS_BUTTONS
+			test_bias_button->activate();
+#endif // CFG_BIAS_BUTTONS
+#ifdef CFG_FLATNESS_BUTTON
+			test_pwr_flatness_button->activate();
+#endif // CFG_FLATNESS_BUTTON
 		}
 		else {
 			setup_button->deactivate();
-			//test_bias_button->deactivate();
+#ifdef CFG_BIAS_BUTTONS
+			test_bias_button->deactivate();
+#endif // CFG_BIAS_BUTTONS
+#ifdef CFG_FLATNESS_BUTTON
+			test_pwr_flatness_button->deactivate();
+#endif // CFG_FLATNESS_BUTTON
 		}
 	}
 
@@ -188,8 +212,13 @@ public:
 		hermes_key_down = 0;
 		hermes_run_state = STATE_IDLE;
 		this->setup_button->deactivate();
-		//this->set_bias_button->deactivate();
-		//this->test_bias_button->deactivate();
+#ifdef CFG_BIAS_BUTTONS
+		this->set_bias_button->deactivate();
+		this->test_bias_button->deactivate();
+#endif // CFG_BIAS_BUTTONS
+#ifdef CFG_FLATNESS_BUTTON
+		this->test_pwr_flatness_button->deactivate();
+#endif // CFG_FLATNESS_BUTTON
 		this->value_mac->copy_label("Unknown");
 		this->value_id->copy_label("Unknown");
 		this->value_ip->copy_label("Unknown");
@@ -277,6 +306,10 @@ void btn_test_bias_callback(Fl_Widget * w, void * d) {
 
 void btn_set_bias_callback(Fl_Widget * w, void * d) {
 	hermes_run_state = STATE_START_SET_BIAS;
+}
+
+void btn_test_pwr_flatness_button_callback(Fl_Widget * w, void * d) {
+	hermes_run_state = STATE_START_TEST_TX_FLATNESS;
 }
 
 void btn_power_callback(Fl_Widget * w, void * d) {


### PR DESCRIPTION
I've added a test to check the relative PA output power at 1.8 MHz and 30 MHz and flag an error if this is outside an 1.1 (&pm; 10%) ratio. These numbers work for my H-Lv2b8 with a rewound T3, I think they should also be fine for a b9 with a good T3 but of course I cannot know for sure.

I've tested this only stand-alone, by adding a dedicated button for this test (uncomment `#define CFG_FLATNESS_BUTTON` in `hl2setup.cxx` to enable the button).
I've tried to add this test as the last test in the overall test suite but I did not check if this is working as I did not want to re-set the bias on my b8 (to avoid altering the PA characteristics, which I have measured a lot of times in different conditions).

Please double-check the added code, as I may have misunderstood how all is supposed to work :grin:.

Not related: [this part](https://github.com/softerhardware/Hermes-Lite2/blob/master/software/hl2setup/hl2.cxx#L502-L505) of the code is either indented incorrectly or some braces are missing but I couldn't figure out how it should be.