### PR TITLE
Tighten up handling of ICMP Unreacahble to make sure that the port number is right

### DIFF
--- a/gateware/rtl/ethernet/icmp.v
+++ b/gateware/rtl/ethernet/icmp.v
@@ -121,7 +121,7 @@ always @(posedge rx_clock)
     // Detection of ICMP dest/port unreachable packet
     ST_UNREACHABLE:
       // skip to the contained UDP header and verify that the source port is
-      // 1024.
+      // 1024 - represented as h04, h00   -- ports are in network byte order.
       begin
         if (skip > 1) skip <= skip - 5'd1;
         else if (skip == 1 && rx_data == 8'h04) skip <= 0;

--- a/gateware/rtl/ethernet/icmp.v
+++ b/gateware/rtl/ethernet/icmp.v
@@ -75,9 +75,9 @@ always @(posedge rx_clock)
             destination_mac <= remote_mac;
             destination_ip <= remote_ip;
             // detection of ICMP dest/port unreachable packet
-	    if (rx_data == 8'h03) begin
-	      state <= ST_UNREACHABLE;
-	      skip <= 5'd28;
+            if (rx_data == 8'h03) begin
+              state <= ST_UNREACHABLE;
+              skip <= 5'd28;
             end
             else
               state <= (rx_data == 8'h08) ? ST_HEADER : ST_DONE;
@@ -123,13 +123,13 @@ always @(posedge rx_clock)
       // skip to the contained UDP header and verify that the source port is
       // 1024.
       begin
-	if (skip > 1) skip <= skip - 5'd1;
-	else if (skip == 1 && rx_data == 8'h04) skip <= 0;
-	else if (skip == 0 && rx_data == 8'h00) begin
-	  dst_unreachable <= 1'b1;
-	  state <= ST_DONE;
-	end
-	else state <= ST_DONE;
+        if (skip > 1) skip <= skip - 5'd1;
+        else if (skip == 1 && rx_data == 8'h04) skip <= 0;
+        else if (skip == 0 && rx_data == 8'h00) begin
+          dst_unreachable <= 1'b1;
+          state <= ST_DONE;
+        end
+        else state <= ST_DONE;
       end
   endcase
 


### PR DESCRIPTION
This fixes #151 -- it turned out that the random ICMP unreachable that was generated for unknown reason during DHCP renewal was triggering behavior in the HL2 to stop sending data. This PR changes the ICMP handling logic. If an ICMP Unreachable is received then the source port in the encapsulated IP packet must be 1024 (the streaming data port). If so, then the flag is set to stop streaming. All other ICMP unreachables are ignored.

Tested locally -- changed my dhcp lease time to 5 minutes and verified that it survives the DHCP renewal. Also, verified that if I kill sparksdr (on a linux box) then the OS sends a small number of icmp unreachables, and the stream of data packets stops.