### PR TITLE
Adding cicrx for Radioberry juice variants.

### DIFF
--- a/gateware/variants/radioberry_juice_cl016_cicrx/.gitignore
+++ b/gateware/variants/radioberry_juice_cl016_cicrx/.gitignore
@@ -1,0 +1,11 @@
+# no backup files
+*.bak
+
+*.qws
+
+db/
+greybox_tmp/
+incremental_db/
+
+build/
+!build/*.rbf

--- a/gateware/variants/radioberry_juice_cl016_cicrx/Makefile
+++ b/gateware/variants/radioberry_juice_cl016_cicrx/Makefile
@@ -1,0 +1,15 @@
+## Quartus tools quartus_sh and quartus_cpf must be in your path
+
+all: build/radioberry.rbf
+
+
+build/radioberry.rbf:
+	quartus_sh --flow compile radioberry -c radioberry
+
+clean:
+	rm -rf build
+
+realclean:
+	rm -rf db incremental_db
+
+.PHONY: all clean realclean

--- a/gateware/variants/radioberry_juice_cl016_cicrx/files.tcl
+++ b/gateware/variants/radioberry_juice_cl016_cicrx/files.tcl
@@ -1,0 +1,91 @@
+
+set_global_assignment -name VERILOG_FILE ../../rtl/radioberry/juice/radioberry_juice_core.v
+set_global_assignment -name VERILOG_FILE ../../rtl/radioberry/juice/radioberry_phy.v
+set_global_assignment -name VERILOG_FILE ../../rtl/radioberry/juice/usopenhpsdr1.v
+set_global_assignment -name VERILOG_FILE ../../rtl/radioberry/juice/dsopenhpsdr1.v
+set_global_assignment -name VERILOG_FILE ../../rtl/radioberry/juice/i2c_bus.v
+set_global_assignment -name VERILOG_FILE ../../rtl/radioberry/juice/control.v
+set_global_assignment -name VERILOG_FILE ../../rtl/radioberry/ad9866ctrl.v
+set_global_assignment -name VERILOG_FILE ../../rtl/radioberry/reset_handler.v
+set_global_assignment -name VERILOG_FILE ../../rtl/radioberry/ad9866pll.v
+
+set_global_assignment -name VERILOG_FILE ../../rtl/fifos.v
+set_global_assignment -name VERILOG_FILE ../../rtl/ad9866.v
+
+set_global_assignment -name VERILOG_FILE ../../rtl/radio_openhpsdr1/radio.v
+set_global_assignment -name VERILOG_FILE ../../rtl/radio_openhpsdr1/varcic.v
+set_global_assignment -name VERILOG_FILE ../../rtl/radio_openhpsdr1/cic.v
+set_global_assignment -name VERILOG_FILE ../../rtl/radio_openhpsdr1/cic_comb.v
+set_global_assignment -name VERILOG_FILE ../../rtl/radio_openhpsdr1/cic_integrator.v
+set_global_assignment -name VERILOG_FILE ../../rtl/radio_openhpsdr1/cordic.v
+set_global_assignment -name VERILOG_FILE ../../rtl/radio_openhpsdr1/cpl_cordic.v
+set_global_assignment -name VERILOG_FILE ../../rtl/radio_openhpsdr1/receiver.v
+set_global_assignment -name VERILOG_FILE ../../rtl/radio_openhpsdr1/firfilt.v
+set_global_assignment -name VERILOG_FILE ../../rtl/radio_openhpsdr1/CicInterpM5.v
+set_global_assignment -name VERILOG_FILE ../../rtl/radio_openhpsdr1/firram36I_1024.v
+set_global_assignment -name VERILOG_FILE ../../rtl/radio_openhpsdr1/FirInterp8_1024.v
+set_global_assignment -name VERILOG_FILE ../../rtl/radio_openhpsdr1/firram36.v
+set_global_assignment -name VERILOG_FILE ../../rtl/radio_openhpsdr1/vna_scanner.v
+set_global_assignment -name VERILOG_FILE ../../rtl/radio_openhpsdr1/firrom/firromH.v
+set_global_assignment -name VERILOG_FILE ../../rtl/radio_openhpsdr1/firrom/firromI_1024.v
+
+set_global_assignment -name VERILOG_FILE ../../rtl/radio_openhpsdr1/FirInterp5_1025_EER.v
+set_global_assignment -name VERILOG_FILE ../../rtl/radio_openhpsdr1/counter.v
+set_global_assignment -name VERILOG_FILE ../../rtl/radio_openhpsdr1/firrom/firrom1_1025.v
+set_global_assignment -name VERILOG_FILE ../../rtl/radio_openhpsdr1/firram36I_205.v
+set_global_assignment -name VERILOG_FILE ../../rtl/radio_openhpsdr1/square.v
+set_global_assignment -name VERILOG_FILE ../../rtl/radio_openhpsdr1/sqroot.v
+
+set_global_assignment -name VERILOG_FILE ../../rtl/primitives/intel/multipliers.v
+set_global_assignment -name VERILOG_FILE ../../rtl/nco/coarserom.v
+set_global_assignment -name VERILOG_FILE ../../rtl/nco/finerom.v
+set_global_assignment -name VERILOG_FILE ../../rtl/nco/sincos.v
+set_global_assignment -name VERILOG_FILE ../../rtl/nco/nco2.v
+set_global_assignment -name VERILOG_FILE ../../rtl/nco/mix2.v
+set_global_assignment -name VERILOG_FILE ../../rtl/radio_openhpsdr1/receiver_ciconly.v
+
+set_global_assignment -name VERILOG_FILE ../../rtl/radio_openhpsdr1/receiver2/recv2_cic.v
+set_global_assignment -name VERILOG_FILE ../../rtl/radio_openhpsdr1/receiver2/recv2_cordic.v
+set_global_assignment -name VERILOG_FILE ../../rtl/radio_openhpsdr1/receiver2/receiver2.v
+set_global_assignment -name VERILOG_FILE ../../rtl/radio_openhpsdr1/receiver2/recv2_firromH.v
+set_global_assignment -name VERILOG_FILE ../../rtl/radio_openhpsdr1/receiver2/recv2_firram48.v
+set_global_assignment -name VERILOG_FILE ../../rtl/radio_openhpsdr1/receiver2/recv2_firx2r2.v
+
+set_global_assignment -name VERILOG_FILE ../../rtl/radio_openhpsdr1/firfilt.v
+set_global_assignment -name VERILOG_FILE ../../rtl/radio_openhpsdr1/CicInterpM5.v
+set_global_assignment -name VERILOG_FILE ../../rtl/radio_openhpsdr1/firram36I_1024.v
+set_global_assignment -name VERILOG_FILE ../../rtl/radio_openhpsdr1/FirInterp8_1024.v
+set_global_assignment -name VERILOG_FILE ../../rtl/radio_openhpsdr1/firram36.v
+set_global_assignment -name VERILOG_FILE ../../rtl/radio_openhpsdr1/vna_scanner.v
+set_global_assignment -name VERILOG_FILE ../../rtl/radio_openhpsdr1/firrom/firromH.v
+set_global_assignment -name VERILOG_FILE ../../rtl/radio_openhpsdr1/firrom/firromI_1024.v
+
+set_global_assignment -name VERILOG_FILE ../../rtl/radio_openhpsdr1/qs1r/qs1r_cic_comb.v
+set_global_assignment -name VERILOG_FILE ../../rtl/radio_openhpsdr1/qs1r/qs1r_cic_integrator.v
+set_global_assignment -name VERILOG_FILE ../../rtl/radio_openhpsdr1/qs1r/qs1r_cordic.v
+set_global_assignment -name VERILOG_FILE ../../rtl/radio_openhpsdr1/qs1r/qs1r_fir.v
+set_global_assignment -name VERILOG_FILE ../../rtl/radio_openhpsdr1/qs1r/qs1r_fir_coeffs.v
+set_global_assignment -name VERILOG_FILE ../../rtl/radio_openhpsdr1/qs1r/qs1r_fir_coeffs_rom.v
+set_global_assignment -name VERILOG_FILE ../../rtl/radio_openhpsdr1/qs1r/qs1r_fir_mac.v
+set_global_assignment -name VERILOG_FILE ../../rtl/radio_openhpsdr1/qs1r/qs1r_fir_shiftreg.v
+set_global_assignment -name VERILOG_FILE ../../rtl/radio_openhpsdr1/qs1r/qs1r_memcic.v
+set_global_assignment -name VERILOG_FILE ../../rtl/radio_openhpsdr1/qs1r/qs1r_memcic_ram.v
+set_global_assignment -name VERILOG_FILE ../../rtl/radio_openhpsdr1/qs1r/qs1r_receiver.v
+set_global_assignment -name VERILOG_FILE ../../rtl/radio_openhpsdr1/qs1r/qs1r_varcic.v
+set_global_assignment -name VERILOG_FILE ../../rtl/radio_openhpsdr1/qs1r/qs1r_mult_24Sx24S.v
+
+
+set_global_assignment -name VERILOG_FILE ../../rtl/cdc_sync.v
+set_global_assignment -name VERILOG_FILE ../../rtl/sync.v
+
+set_global_assignment -name VERILOG_FILE ../../rtl/led_flash.v
+set_global_assignment -name VERILOG_FILE ../../rtl/cw_basic.v
+set_global_assignment -name VERILOG_FILE ../../rtl/cw_openhpsdr.v
+set_global_assignment -name VERILOG_FILE ../../rtl/iambic.v
+set_global_assignment -name VERILOG_FILE ../../rtl/debounce.v
+set_global_assignment -name VERILOG_FILE ../../rtl/i2c_master.v
+set_global_assignment -name VERILOG_FILE ../../rtl/i2c.v
+set_global_assignment -name VERILOG_FILE ../../rtl/slow_adc.v
+set_global_assignment -name VERILOG_FILE ../../rtl/extamp.v
+set_global_assignment -name VERILOG_FILE ../../rtl/exttuner.v
+set_global_assignment -name VERILOG_FILE ../../rtl/hl2link.v

--- a/gateware/variants/radioberry_juice_cl016_cicrx/radioberry.qpf
+++ b/gateware/variants/radioberry_juice_cl016_cicrx/radioberry.qpf
@@ -1,0 +1,31 @@
+# -------------------------------------------------------------------------- #
+#
+# Copyright (C) 2020  Intel Corporation. All rights reserved.
+# Your use of Intel Corporation's design tools, logic functions 
+# and other software and tools, and any partner logic 
+# functions, and any output files from any of the foregoing 
+# (including device programming or simulation files), and any 
+# associated documentation or information are expressly subject 
+# to the terms and conditions of the Intel Program License 
+# Subscription Agreement, the Intel Quartus Prime License Agreement,
+# the Intel FPGA IP License Agreement, or other applicable license
+# agreement, including, without limitation, that your use is for
+# the sole purpose of programming logic devices manufactured by
+# Intel and sold by Intel or its authorized distributors.  Please
+# refer to the applicable agreement for further details, at
+# https://fpgasoftware.intel.com/eula.
+#
+# -------------------------------------------------------------------------- #
+#
+# Quartus Prime
+# Version 20.1.0 Build 711 06/05/2020 SJ Lite Edition
+# Date created = 07:47:07  May 26, 2021
+#
+# -------------------------------------------------------------------------- #
+
+QUARTUS_VERSION = "20.1"
+DATE = "07:47:07  May 26, 2021"
+
+# Revisions
+
+PROJECT_REVISION = "radioberry"

--- a/gateware/variants/radioberry_juice_cl016_cicrx/radioberry.qsf
+++ b/gateware/variants/radioberry_juice_cl016_cicrx/radioberry.qsf
@@ -1,0 +1,62 @@
+# -------------------------------------------------------------------------- #
+#
+# Copyright (C) 2020  Intel Corporation. All rights reserved.
+# Your use of Intel Corporation's design tools, logic functions 
+# and other software and tools, and any partner logic 
+# functions, and any output files from any of the foregoing 
+# (including device programming or simulation files), and any 
+# associated documentation or information are expressly subject 
+# to the terms and conditions of the Intel Program License 
+# Subscription Agreement, the Intel Quartus Prime License Agreement,
+# the Intel FPGA IP License Agreement, or other applicable license
+# agreement, including, without limitation, that your use is for
+# the sole purpose of programming logic devices manufactured by
+# Intel and sold by Intel or its authorized distributors.  Please
+# refer to the applicable agreement for further details, at
+# https://fpgasoftware.intel.com/eula.
+#
+# -------------------------------------------------------------------------- #
+#
+# Quartus Prime
+# Version 20.1.0 Build 711 06/05/2020 SJ Lite Edition
+# Date created = 08:06:28  May 26, 2021
+#
+# -------------------------------------------------------------------------- #
+#
+# Notes:
+#
+# 1) The default values for assignments are stored in the file:
+#		radioberry_assignment_defaults.qdf
+#    If this file doesn't exist, see file:
+#		assignment_defaults.qdf
+#
+# 2) Altera recommends that you do not modify this file. This
+#    file is updated automatically by the Quartus Prime software
+#    and any changes you make may be lost or overwritten.
+#
+# -------------------------------------------------------------------------- #
+
+
+set_global_assignment -name DEVICE 10CL016YE144C8G
+
+set_global_assignment -name VERILOG_MACRO "USE_ALTSYNCRAM=1"
+set_global_assignment -name PROJECT_OUTPUT_DIRECTORY build
+source ../../boards/radioberry-juice/general.tcl
+source ../../boards/radioberry-juice/pins.tcl
+source ./files.tcl
+
+set_global_assignment -name VERILOG_FILE ./radioberry.v
+set_global_assignment -name TOP_LEVEL_ENTITY radioberry
+set_global_assignment -name SDC_FILE "../../boards/radioberry-juice/timing.sdc"
+
+set_global_assignment -name LAST_QUARTUS_VERSION "20.1.1 Lite Edition"
+
+set_global_assignment -name NUM_PARALLEL_PROCESSORS ALL
+set_global_assignment -name TIMING_ANALYZER_MULTICORNER_ANALYSIS ON
+set_global_assignment -name SMART_RECOMPILE ON
+set_global_assignment -name FLOW_ENABLE_IO_ASSIGNMENT_ANALYSIS ON
+set_global_assignment -name MIN_CORE_JUNCTION_TEMP 0
+set_global_assignment -name MAX_CORE_JUNCTION_TEMP 85
+set_global_assignment -name POWER_PRESET_COOLING_SOLUTION "23 MM HEAT SINK WITH 200 LFPM AIRFLOW"
+set_global_assignment -name POWER_BOARD_THERMAL_MODEL "NONE (CONSERVATIVE)"
+set_instance_assignment -name PARTITION_HIERARCHY root_partition -to | -section_id Top

--- a/gateware/variants/radioberry_juice_cl016_cicrx/radioberry.v
+++ b/gateware/variants/radioberry_juice_cl016_cicrx/radioberry.v
@@ -1,0 +1,91 @@
+
+//  radioberry using juice board.
+
+
+// following Hermeslite setup as defined by Steve Haynal KF7O
+
+
+module radioberry (
+
+	//RF Frontend
+	output          rffe_ad9866_rst_n,
+	output  [5:0]   rffe_ad9866_tx,
+	input   [5:0]   rffe_ad9866_rx,
+	input           rffe_ad9866_rxsync,
+	input           rffe_ad9866_rxclk,  
+	output          rffe_ad9866_txquiet_n,
+	output          rffe_ad9866_txsync,
+	output          rffe_ad9866_sdio,
+	output          rffe_ad9866_sclk,
+	output          rffe_ad9866_sen_n,
+	input           rffe_ad9866_clk76p8,
+	output          rffe_ad9866_mode,
+	
+	// Juice interface; based on FTDI 
+	input  			ftd_clk_60,
+    inout	[7:0] 	ftd_data, 
+	output			output_enable_ftd_n,  
+    input			ftd_rx_fifo_empty,  
+    output			read_rx_fifo_ftd_n,
+    input  			ftd_tx_fifo_full,                  
+    output 			write_tx_fifo_ftd_n,  
+    output 			send_immediately_ftd_n, 
+          
+	// Radioberry IO
+	input           io_phone_tip,
+	input           io_phone_ring,
+	output 			io_pa_exttr,
+	output       	io_pa_inttr,
+	
+	// Power
+	output			io_pwr_envpa,
+	output			io_pwr_envbias,
+	
+	// I2C
+	inout        	io_scl,
+	inout        	io_sda
+);
+
+
+  radioberry_juice_core #(
+    .NR   		(8                                  ),
+    .NT   		(0                                  ),
+    .UART 		(0                                  ),
+    .ATU  		(0                                  ),
+	.VNA 		(0									),
+	.FAN        (1                                  ),
+	.CW   		(1									),
+	.FPGA_TYPE  (1									)
+  ) radioberry_juice_core_i (
+ 
+    .rffe_ad9866_rst_n         	(rffe_ad9866_rst_n    ),
+    .rffe_ad9866_tx            	(rffe_ad9866_tx       ),
+    .rffe_ad9866_rx            	(rffe_ad9866_rx       ),
+    .rffe_ad9866_rxsync        	(rffe_ad9866_rxsync   ),
+    .rffe_ad9866_rxclk        	(rffe_ad9866_rxclk    ),
+    .rffe_ad9866_txquiet_n    	(rffe_ad9866_txquiet_n),
+    .rffe_ad9866_txsync       	(rffe_ad9866_txsync   ),
+    .rffe_ad9866_sdio         	(rffe_ad9866_sdio     ),
+    .rffe_ad9866_sclk         	(rffe_ad9866_sclk     ),
+    .rffe_ad9866_sen_n        	(rffe_ad9866_sen_n    ),
+    .rffe_ad9866_clk76p8       	(rffe_ad9866_clk76p8  ),
+    .rffe_ad9866_mode          	(rffe_ad9866_mode     ),
+	.ftd_clk_60					(ftd_clk_60),
+    .ftd_data					(ftd_data), 
+	.output_enable_ftd_n		(output_enable_ftd_n),  
+    .ftd_rx_fifo_empty			(ftd_rx_fifo_empty),  
+    .read_rx_fifo_ftd_n			(read_rx_fifo_ftd_n),
+    .ftd_tx_fifo_full			(ftd_tx_fifo_full),                  
+    .write_tx_fifo_ftd_n		(write_tx_fifo_ftd_n),  
+    .send_immediately_ftd_n		(send_immediately_ftd_n), 	
+	.io_phone_tip				(io_phone_tip),
+	.io_phone_ring				(io_phone_ring),
+	.io_pa_exttr				(io_pa_exttr),
+	.io_pa_inttr				(io_pa_inttr),
+	.io_pwr_envpa				(io_pwr_envpa),
+	.io_pwr_envbias				(io_pwr_envbias),
+	.io_scl						(io_scl),
+	.io_sda						(io_sda)
+  );
+
+endmodule

--- a/gateware/variants/radioberry_juice_cl025_cicrx/.gitignore
+++ b/gateware/variants/radioberry_juice_cl025_cicrx/.gitignore
@@ -1,0 +1,11 @@
+# no backup files
+*.bak
+
+*.qws
+
+db/
+greybox_tmp/
+incremental_db/
+
+build/
+!build/*.rbf

--- a/gateware/variants/radioberry_juice_cl025_cicrx/Makefile
+++ b/gateware/variants/radioberry_juice_cl025_cicrx/Makefile
@@ -1,0 +1,15 @@
+## Quartus tools quartus_sh and quartus_cpf must be in your path
+
+all: build/radioberry.rbf
+
+
+build/radioberry.rbf:
+	quartus_sh --flow compile radioberry -c radioberry
+
+clean:
+	rm -rf build
+
+realclean:
+	rm -rf db incremental_db
+
+.PHONY: all clean realclean

--- a/gateware/variants/radioberry_juice_cl025_cicrx/files.tcl
+++ b/gateware/variants/radioberry_juice_cl025_cicrx/files.tcl
@@ -1,0 +1,92 @@
+
+set_global_assignment -name VERILOG_FILE ../../rtl/radioberry/juice/radioberry_juice_core.v
+set_global_assignment -name VERILOG_FILE ../../rtl/radioberry/juice/radioberry_phy.v
+set_global_assignment -name VERILOG_FILE ../../rtl/radioberry/juice/usopenhpsdr1.v
+set_global_assignment -name VERILOG_FILE ../../rtl/radioberry/juice/dsopenhpsdr1.v
+set_global_assignment -name VERILOG_FILE ../../rtl/radioberry/juice/i2c_bus.v
+set_global_assignment -name VERILOG_FILE ../../rtl/radioberry/juice/control.v
+set_global_assignment -name VERILOG_FILE ../../rtl/radioberry/ad9866ctrl.v
+set_global_assignment -name VERILOG_FILE ../../rtl/radioberry/reset_handler.v
+set_global_assignment -name VERILOG_FILE ../../rtl/radioberry/ad9866pll.v
+
+set_global_assignment -name VERILOG_FILE ../../rtl/fifos.v
+set_global_assignment -name VERILOG_FILE ../../rtl/ad9866.v
+
+set_global_assignment -name VERILOG_FILE ../../rtl/radio_openhpsdr1/radio.v
+set_global_assignment -name VERILOG_FILE ../../rtl/radio_openhpsdr1/varcic.v
+set_global_assignment -name VERILOG_FILE ../../rtl/radio_openhpsdr1/cic.v
+set_global_assignment -name VERILOG_FILE ../../rtl/radio_openhpsdr1/cic_comb.v
+set_global_assignment -name VERILOG_FILE ../../rtl/radio_openhpsdr1/cic_integrator.v
+set_global_assignment -name VERILOG_FILE ../../rtl/radio_openhpsdr1/cordic.v
+set_global_assignment -name VERILOG_FILE ../../rtl/radio_openhpsdr1/cpl_cordic.v
+set_global_assignment -name VERILOG_FILE ../../rtl/radio_openhpsdr1/receiver.v
+set_global_assignment -name VERILOG_FILE ../../rtl/radio_openhpsdr1/firfilt.v
+set_global_assignment -name VERILOG_FILE ../../rtl/radio_openhpsdr1/CicInterpM5.v
+set_global_assignment -name VERILOG_FILE ../../rtl/radio_openhpsdr1/firram36I_1024.v
+set_global_assignment -name VERILOG_FILE ../../rtl/radio_openhpsdr1/FirInterp8_1024.v
+set_global_assignment -name VERILOG_FILE ../../rtl/radio_openhpsdr1/firram36.v
+set_global_assignment -name VERILOG_FILE ../../rtl/radio_openhpsdr1/vna_scanner.v
+set_global_assignment -name VERILOG_FILE ../../rtl/radio_openhpsdr1/firrom/firromH.v
+set_global_assignment -name VERILOG_FILE ../../rtl/radio_openhpsdr1/firrom/firromI_1024.v
+
+set_global_assignment -name VERILOG_FILE ../../rtl/radio_openhpsdr1/FirInterp5_1025_EER.v
+set_global_assignment -name VERILOG_FILE ../../rtl/radio_openhpsdr1/counter.v
+set_global_assignment -name VERILOG_FILE ../../rtl/radio_openhpsdr1/firrom/firrom1_1025.v
+set_global_assignment -name VERILOG_FILE ../../rtl/radio_openhpsdr1/firram36I_205.v
+set_global_assignment -name VERILOG_FILE ../../rtl/radio_openhpsdr1/square.v
+set_global_assignment -name VERILOG_FILE ../../rtl/radio_openhpsdr1/sqroot.v
+
+set_global_assignment -name VERILOG_FILE ../../rtl/primitives/intel/multipliers.v
+set_global_assignment -name VERILOG_FILE ../../rtl/nco/coarserom.v
+set_global_assignment -name VERILOG_FILE ../../rtl/nco/finerom.v
+set_global_assignment -name VERILOG_FILE ../../rtl/nco/sincos.v
+set_global_assignment -name VERILOG_FILE ../../rtl/nco/nco2.v
+set_global_assignment -name VERILOG_FILE ../../rtl/nco/mix2.v
+set_global_assignment -name VERILOG_FILE ../../rtl/radio_openhpsdr1/receiver_ciconly.v
+
+set_global_assignment -name VERILOG_FILE ../../rtl/radio_openhpsdr1/receiver2/recv2_cic.v
+set_global_assignment -name VERILOG_FILE ../../rtl/radio_openhpsdr1/receiver2/recv2_cordic.v
+set_global_assignment -name VERILOG_FILE ../../rtl/radio_openhpsdr1/receiver2/receiver2.v
+set_global_assignment -name VERILOG_FILE ../../rtl/radio_openhpsdr1/receiver2/recv2_firromH.v
+set_global_assignment -name VERILOG_FILE ../../rtl/radio_openhpsdr1/receiver2/recv2_firram48.v
+set_global_assignment -name VERILOG_FILE ../../rtl/radio_openhpsdr1/receiver2/recv2_firx2r2.v
+
+set_global_assignment -name VERILOG_FILE ../../rtl/radio_openhpsdr1/firfilt.v
+set_global_assignment -name VERILOG_FILE ../../rtl/radio_openhpsdr1/CicInterpM5.v
+set_global_assignment -name VERILOG_FILE ../../rtl/radio_openhpsdr1/firram36I_1024.v
+set_global_assignment -name VERILOG_FILE ../../rtl/radio_openhpsdr1/FirInterp8_1024.v
+set_global_assignment -name VERILOG_FILE ../../rtl/radio_openhpsdr1/firram36.v
+set_global_assignment -name VERILOG_FILE ../../rtl/radio_openhpsdr1/vna_scanner.v
+set_global_assignment -name VERILOG_FILE ../../rtl/radio_openhpsdr1/firrom/firromH.v
+set_global_assignment -name VERILOG_FILE ../../rtl/radio_openhpsdr1/firrom/firromI_1024.v
+
+set_global_assignment -name VERILOG_FILE ../../rtl/radio_openhpsdr1/qs1r/qs1r_cic_comb.v
+set_global_assignment -name VERILOG_FILE ../../rtl/radio_openhpsdr1/qs1r/qs1r_cic_integrator.v
+set_global_assignment -name VERILOG_FILE ../../rtl/radio_openhpsdr1/qs1r/qs1r_cordic.v
+set_global_assignment -name VERILOG_FILE ../../rtl/radio_openhpsdr1/qs1r/qs1r_fir.v
+set_global_assignment -name VERILOG_FILE ../../rtl/radio_openhpsdr1/qs1r/qs1r_fir_coeffs.v
+set_global_assignment -name VERILOG_FILE ../../rtl/radio_openhpsdr1/qs1r/qs1r_fir_coeffs_rom.v
+set_global_assignment -name VERILOG_FILE ../../rtl/radio_openhpsdr1/qs1r/qs1r_fir_mac.v
+set_global_assignment -name VERILOG_FILE ../../rtl/radio_openhpsdr1/qs1r/qs1r_fir_shiftreg.v
+set_global_assignment -name VERILOG_FILE ../../rtl/radio_openhpsdr1/qs1r/qs1r_memcic.v
+set_global_assignment -name VERILOG_FILE ../../rtl/radio_openhpsdr1/qs1r/qs1r_memcic_ram.v
+set_global_assignment -name VERILOG_FILE ../../rtl/radio_openhpsdr1/qs1r/qs1r_receiver.v
+set_global_assignment -name VERILOG_FILE ../../rtl/radio_openhpsdr1/qs1r/qs1r_varcic.v
+set_global_assignment -name VERILOG_FILE ../../rtl/radio_openhpsdr1/qs1r/qs1r_mult_24Sx24S.v
+
+
+set_global_assignment -name VERILOG_FILE ../../rtl/cdc_sync.v
+set_global_assignment -name VERILOG_FILE ../../rtl/sync.v
+
+set_global_assignment -name VERILOG_FILE ../../rtl/led_flash.v
+set_global_assignment -name VERILOG_FILE ../../rtl/cw_basic.v
+set_global_assignment -name VERILOG_FILE ../../rtl/cw_openhpsdr.v
+set_global_assignment -name VERILOG_FILE ../../rtl/iambic.v
+set_global_assignment -name VERILOG_FILE ../../rtl/debounce.v
+set_global_assignment -name VERILOG_FILE ../../rtl/i2c_master.v
+set_global_assignment -name VERILOG_FILE ../../rtl/i2c.v
+set_global_assignment -name VERILOG_FILE ../../rtl/slow_adc.v
+set_global_assignment -name VERILOG_FILE ../../rtl/extamp.v
+set_global_assignment -name VERILOG_FILE ../../rtl/exttuner.v
+set_global_assignment -name VERILOG_FILE ../../rtl/hl2link.v
+

--- a/gateware/variants/radioberry_juice_cl025_cicrx/radioberry.qpf
+++ b/gateware/variants/radioberry_juice_cl025_cicrx/radioberry.qpf
@@ -1,0 +1,31 @@
+# -------------------------------------------------------------------------- #
+#
+# Copyright (C) 2020  Intel Corporation. All rights reserved.
+# Your use of Intel Corporation's design tools, logic functions 
+# and other software and tools, and any partner logic 
+# functions, and any output files from any of the foregoing 
+# (including device programming or simulation files), and any 
+# associated documentation or information are expressly subject 
+# to the terms and conditions of the Intel Program License 
+# Subscription Agreement, the Intel Quartus Prime License Agreement,
+# the Intel FPGA IP License Agreement, or other applicable license
+# agreement, including, without limitation, that your use is for
+# the sole purpose of programming logic devices manufactured by
+# Intel and sold by Intel or its authorized distributors.  Please
+# refer to the applicable agreement for further details, at
+# https://fpgasoftware.intel.com/eula.
+#
+# -------------------------------------------------------------------------- #
+#
+# Quartus Prime
+# Version 20.1.0 Build 711 06/05/2020 SJ Lite Edition
+# Date created = 07:47:07  May 26, 2021
+#
+# -------------------------------------------------------------------------- #
+
+QUARTUS_VERSION = "20.1"
+DATE = "07:47:07  May 26, 2021"
+
+# Revisions
+
+PROJECT_REVISION = "radioberry"

--- a/gateware/variants/radioberry_juice_cl025_cicrx/radioberry.qsf
+++ b/gateware/variants/radioberry_juice_cl025_cicrx/radioberry.qsf
@@ -1,0 +1,69 @@
+# -------------------------------------------------------------------------- #
+#
+# Copyright (C) 2020  Intel Corporation. All rights reserved.
+# Your use of Intel Corporation's design tools, logic functions 
+# and other software and tools, and any partner logic 
+# functions, and any output files from any of the foregoing 
+# (including device programming or simulation files), and any 
+# associated documentation or information are expressly subject 
+# to the terms and conditions of the Intel Program License 
+# Subscription Agreement, the Intel Quartus Prime License Agreement,
+# the Intel FPGA IP License Agreement, or other applicable license
+# agreement, including, without limitation, that your use is for
+# the sole purpose of programming logic devices manufactured by
+# Intel and sold by Intel or its authorized distributors.  Please
+# refer to the applicable agreement for further details, at
+# https://fpgasoftware.intel.com/eula.
+#
+# -------------------------------------------------------------------------- #
+#
+# Quartus Prime
+# Version 20.1.0 Build 711 06/05/2020 SJ Lite Edition
+# Date created = 08:06:28  May 26, 2021
+#
+# -------------------------------------------------------------------------- #
+#
+# Notes:
+#
+# 1) The default values for assignments are stored in the file:
+#		radioberry_assignment_defaults.qdf
+#    If this file doesn't exist, see file:
+#		assignment_defaults.qdf
+#
+# 2) Altera recommends that you do not modify this file. This
+#    file is updated automatically by the Quartus Prime software
+#    and any changes you make may be lost or overwritten.
+#
+# -------------------------------------------------------------------------- #
+
+
+set_global_assignment -name DEVICE 10CL025YE144C8G
+
+set_global_assignment -name VERILOG_MACRO "USE_ALTSYNCRAM=1"
+set_global_assignment -name PROJECT_OUTPUT_DIRECTORY build
+source ../../boards/radioberry-juice/general.tcl
+source ../../boards/radioberry-juice/pins.tcl
+source ./files.tcl
+
+set_global_assignment -name VERILOG_FILE ./radioberry.v
+set_global_assignment -name TOP_LEVEL_ENTITY radioberry
+set_global_assignment -name SDC_FILE "../../boards/radioberry-juice/timing.sdc"
+
+set_global_assignment -name LAST_QUARTUS_VERSION "20.1.1 Lite Edition"
+
+
+set_global_assignment -name TIMING_ANALYZER_MULTICORNER_ANALYSIS ON
+set_global_assignment -name SMART_RECOMPILE ON
+set_global_assignment -name NUM_PARALLEL_PROCESSORS ALL
+set_global_assignment -name FLOW_ENABLE_IO_ASSIGNMENT_ANALYSIS ON
+set_global_assignment -name MIN_CORE_JUNCTION_TEMP 0
+set_global_assignment -name MAX_CORE_JUNCTION_TEMP 85
+set_global_assignment -name POWER_PRESET_COOLING_SOLUTION "23 MM HEAT SINK WITH 200 LFPM AIRFLOW"
+set_global_assignment -name POWER_BOARD_THERMAL_MODEL "NONE (CONSERVATIVE)"
+
+
+
+
+
+
+set_instance_assignment -name PARTITION_HIERARCHY root_partition -to | -section_id Top

--- a/gateware/variants/radioberry_juice_cl025_cicrx/radioberry.v
+++ b/gateware/variants/radioberry_juice_cl025_cicrx/radioberry.v
@@ -1,0 +1,91 @@
+
+//  radioberry using juice board.
+
+
+// following Hermeslite setup as defined by Steve Haynal KF7O
+
+
+module radioberry (
+
+	//RF Frontend
+	output          rffe_ad9866_rst_n,
+	output  [5:0]   rffe_ad9866_tx,
+	input   [5:0]   rffe_ad9866_rx,
+	input           rffe_ad9866_rxsync,
+	input           rffe_ad9866_rxclk,  
+	output          rffe_ad9866_txquiet_n,
+	output          rffe_ad9866_txsync,
+	output          rffe_ad9866_sdio,
+	output          rffe_ad9866_sclk,
+	output          rffe_ad9866_sen_n,
+	input           rffe_ad9866_clk76p8,
+	output          rffe_ad9866_mode,
+	
+	// Juice interface; based on FTDI 
+	input  			ftd_clk_60,
+    inout	[7:0] 	ftd_data, 
+	output			output_enable_ftd_n,  
+    input			ftd_rx_fifo_empty,  
+    output			read_rx_fifo_ftd_n,
+    input  			ftd_tx_fifo_full,                  
+    output 			write_tx_fifo_ftd_n,  
+    output 			send_immediately_ftd_n, 
+          
+	// Radioberry IO
+	input           io_phone_tip,
+	input           io_phone_ring,
+	output 			io_pa_exttr,
+	output       	io_pa_inttr,
+	
+	// Power
+	output			io_pwr_envpa,
+	output			io_pwr_envbias,
+	
+	// I2C
+	inout        	io_scl,
+	inout        	io_sda
+);
+
+
+  radioberry_juice_core #(
+    .NR   		(10                                  ),
+    .NT   		(0                                  ),
+    .UART 		(0                                  ),
+    .ATU  		(0                                  ),
+	.VNA 		(0									),
+	.FAN        (1                                  ),
+	.CW   		(1									),
+	.FPGA_TYPE  (2									)
+  ) radioberry_juice_core_i (
+ 
+    .rffe_ad9866_rst_n         	(rffe_ad9866_rst_n    ),
+    .rffe_ad9866_tx            	(rffe_ad9866_tx       ),
+    .rffe_ad9866_rx            	(rffe_ad9866_rx       ),
+    .rffe_ad9866_rxsync        	(rffe_ad9866_rxsync   ),
+    .rffe_ad9866_rxclk        	(rffe_ad9866_rxclk    ),
+    .rffe_ad9866_txquiet_n    	(rffe_ad9866_txquiet_n),
+    .rffe_ad9866_txsync       	(rffe_ad9866_txsync   ),
+    .rffe_ad9866_sdio         	(rffe_ad9866_sdio     ),
+    .rffe_ad9866_sclk         	(rffe_ad9866_sclk     ),
+    .rffe_ad9866_sen_n        	(rffe_ad9866_sen_n    ),
+    .rffe_ad9866_clk76p8       	(rffe_ad9866_clk76p8  ),
+    .rffe_ad9866_mode          	(rffe_ad9866_mode     ),
+	.ftd_clk_60					(ftd_clk_60),
+    .ftd_data					(ftd_data), 
+	.output_enable_ftd_n		(output_enable_ftd_n),  
+    .ftd_rx_fifo_empty			(ftd_rx_fifo_empty),  
+    .read_rx_fifo_ftd_n			(read_rx_fifo_ftd_n),
+    .ftd_tx_fifo_full			(ftd_tx_fifo_full),                  
+    .write_tx_fifo_ftd_n		(write_tx_fifo_ftd_n),  
+    .send_immediately_ftd_n		(send_immediately_ftd_n), 	
+	.io_phone_tip				(io_phone_tip),
+	.io_phone_ring				(io_phone_ring),
+	.io_pa_exttr				(io_pa_exttr),
+	.io_pa_inttr				(io_pa_inttr),
+	.io_pwr_envpa				(io_pwr_envpa),
+	.io_pwr_envbias				(io_pwr_envbias),
+	.io_scl						(io_scl),
+	.io_sda						(io_sda)
+  );
+
+endmodule


### PR DESCRIPTION
Steve, I pulled in the file.tcl from 
../../boards/radioberry-juice/files.tcl
because it had conflicts with
set_global_assignment -name VERILOG_FILE ../../rtl/radio_openhpsdr1/receiver_nco.v
verses
set_global_assignment -name VERILOG_FILE ../../rtl/radio_openhpsdr1/receiver_ciconly.v

Maybe there is a better way to override receiver_nco.v ?